### PR TITLE
Add DNSSEC support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.11
 
 LABEL maintainer "opsxcq@strm.sh"
 
-RUN apk --no-cache add dnsmasq
+RUN apk --no-cache add dnsmasq-dnssec
 
 VOLUME /etc/dnsmasq
 


### PR DESCRIPTION
Can be enabled with
```
conf-file=/usr/share/dnsmasq/trust-anchors.conf
dnssec
```